### PR TITLE
feat: Add login and logout commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ supabase/.temp/
 supabase/.branches/
 PR.md
 .env
+.flake8

--- a/cli_unites/commands/__init__.py
+++ b/cli_unites/commands/__init__.py
@@ -1,4 +1,5 @@
 """CLI command registrations."""
+
 from __future__ import annotations
 
 from typing import Iterable
@@ -13,8 +14,21 @@ from .list import list_notes
 from .onboarding import onboarding
 from .search import search
 from .team import team
+from .login import login
+from .logout import logout  
 
-COMMANDS = (add, auth, list_notes, search, team, help_command, activity, onboarding)
+COMMANDS = (
+    add,
+    auth,
+    list_notes,
+    search,
+    team,
+    help_command,
+    activity,
+    onboarding,
+    login,
+    logout,
+)    
 
 
 def register(group: Group, commands: Iterable = COMMANDS) -> None:

--- a/cli_unites/commands/help.py
+++ b/cli_unites/commands/help.py
@@ -7,12 +7,15 @@ from ..core import console
 
 HELP_CONTENT = """[bold]cli-unites quick start[/bold]
 
-• [bold]Authenticate[/bold]: `notes auth --token TOKEN --team-id TEAM`
-• [bold]Add notes[/bold]: `notes add "Title" --body "Details"`
-• [bold]List notes[/bold]: `notes list --tag release`
-• [bold]Search[/bold]: `notes search "keyword"`
-• [bold]Switch team[/bold]: `notes team --set my-team`
-• [bold]Team activity[/bold]: `notes activity --limit 5`
+• [bold]Authentication[/bold]: `notes auth --token TOKEN --team-id TEAM`
+• [bold]Login[/bold]: `notes login`
+• [bold]Logout[/bold]: `notes logout`
+• [bold]Add Note[/bold]: `notes add "Title" --body "Details"`
+• [bold]List Notes[/bold]: `notes list --tag release`
+• [bold]Search Notes[/bold]: `notes search "keyword"`
+• [bold]Switch Team[/bold]: `notes team --set my-team`
+• [bold]Team Activity[/bold]: `notes activity --limit 5`
+
 
 Tips:
 - Omit `--body` to open an editor or pipe text from another command.
@@ -27,4 +30,9 @@ def help_command(topic: str | None) -> None:
     """Show usage tips and quick links."""
     console.print(Panel.fit(HELP_CONTENT, border_style="cyan"))
     if topic:
-        console.print(f"[dim]No detailed walkthrough for [bold]{topic}[/bold] yet. Try the README or `notes help` without a topic.[/dim]")
+        console.print(
+            (
+                f"[dim]No detailed walkthrough for [bold]{topic}[/bold] yet. "
+                "Try the README or `notes help` without a topic.[/dim]"
+            )
+        )

--- a/cli_unites/commands/list.py
+++ b/cli_unites/commands/list.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+
 from ..core import console, print_warning, render_note_panel, render_notes_table
 from ..core.config import ConfigManager
 from ..core.db import get_connection

--- a/cli_unites/commands/login.py
+++ b/cli_unites/commands/login.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+import rich_click as click
+from ..core.auth import handle_login_flow
+
+
+@click.command(name="login")
+def login() -> None:
+    handle_login_flow()

--- a/cli_unites/commands/logout.py
+++ b/cli_unites/commands/logout.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+import rich_click as click
+from ..core.output import print_success
+from ..core.config import ConfigManager
+
+
+@click.command(name="logout")
+def logout() -> None:
+    config = ConfigManager()
+    config.update({"auth_token": None, "refresh_token": None})
+    print_success("Successfully logged out and cleared authentication tokens.")

--- a/cli_unites/core/auth.py
+++ b/cli_unites/core/auth.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-
+import os
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlparse
@@ -8,6 +8,9 @@ import threading
 from ..database.create_client import supabase
 from .config import ConfigManager
 from .output import console, render_status_panel, print_success, print_error
+
+# Get the absolute path to the templates directory
+TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), '..', 'templates')
 
 
 def serialize_datetime(obj):
@@ -89,24 +92,19 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
 
                 print_success("Successfully authenticated!")
 
-                self.wfile.write(
-                    b"<html><body><h1>Authentication successful!</h1>"
-                    b"<p>You can close this window.</p></body></html>"
-                )
+                with open(os.path.join(TEMPLATES_DIR, 'success.html'), 'rb') as f:
+                    self.wfile.write(f.read())
+
             except Exception as e:
                 print_error(f"Error exchanging code for session: {e}")
-                self.wfile.write(
-                    b"<html><body><h1>Authentication failed.</h1>"
-                    b"<p>Error exchanging code for session.</p></body></html>"
-                )
+                with open(os.path.join(TEMPLATES_DIR, 'error.html'), 'rb') as f:
+                    self.wfile.write(f.read())
 
             # Shutdown server after handling the request
             threading.Thread(target=self.server.shutdown).start()
         else:
-            self.wfile.write(
-                b"<html><body><h1>Authentication failed.</h1>"
-                b"<p>No authorization code found.</p></body></html>"
-            )
+            with open(os.path.join(TEMPLATES_DIR, 'error.html'), 'rb') as f:
+                self.wfile.write(f.read())
 
 
 def handle_login_flow() -> None:

--- a/cli_unites/core/auth.py
+++ b/cli_unites/core/auth.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+import threading
+from ..database.create_client import supabase
+from .config import ConfigManager
+from .output import console, render_status_panel, print_success, print_error
+
+
+def serialize_datetime(obj):
+    """Convert datetime to ISO string for JSON serialization."""
+    if hasattr(obj, "isoformat"):
+        return obj.isoformat()
+    return obj
+
+
+def user_to_dict(user):
+    return {
+        "id": user.id,
+        "aud": user.aud,
+        "role": user.role,
+        "email": user.email,
+        "email_confirmed_at": serialize_datetime(
+            getattr(user, "email_confirmed_at", None)
+        ),
+        "phone": getattr(user, "phone", None),
+        "confirmation_sent_at": serialize_datetime(
+            getattr(user, "confirmation_sent_at", None)
+        ),
+        "confirmed_at": serialize_datetime(getattr(user, "confirmed_at", None)),
+        "last_sign_in_at": serialize_datetime(getattr(user, "last_sign_in_at", None)),
+        "app_metadata": getattr(user, "app_metadata", {}),
+        "user_metadata": getattr(user, "user_metadata", {}),
+        "identities": [
+            {
+                k: serialize_datetime(v) if hasattr(v, "isoformat") else v
+                for k, v in dict(i).items()
+            }
+            for i in getattr(user, "identities", [])
+        ],
+        "created_at": serialize_datetime(getattr(user, "created_at", None)),
+        "updated_at": serialize_datetime(getattr(user, "updated_at", None)),
+        "is_anonymous": getattr(user, "is_anonymous", False),
+    }
+
+
+def session_to_dict(session):
+    return {
+        "access_token": session.access_token,
+        "token_type": getattr(session, "token_type", None),
+        "expires_in": session.expires_in,
+        "expires_at": serialize_datetime(getattr(session, "expires_at", None)),
+        "refresh_token": session.refresh_token,
+        "user": user_to_dict(session.user),
+        "provider_token": getattr(session, "provider_token", None),
+        "provider_refresh_token": getattr(session, "provider_refresh_token", None),
+    }
+
+
+class OAuthCallbackHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed_path = urlparse(self.path)
+        query_params = parse_qs(parsed_path.query)
+        code = query_params.get("code", [None])[0]
+
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+
+        if code:
+            try:
+                # Exchange the authorization code for a session
+                auth_response = supabase.auth.exchange_code_for_session(
+                    {"auth_code": code}
+                )
+
+                # Convert session and user to dicts
+                session_data = session_to_dict(auth_response.session)
+                config = ConfigManager()
+                config.update(
+                    {
+                        "auth_token": session_data["access_token"],
+                        "refresh_token": session_data["refresh_token"],
+                    }
+                )
+
+                print_success("Successfully authenticated!")
+
+                self.wfile.write(
+                    b"<html><body><h1>Authentication successful!</h1>"
+                    b"<p>You can close this window.</p></body></html>"
+                )
+            except Exception as e:
+                print_error(f"Error exchanging code for session: {e}")
+                self.wfile.write(
+                    b"<html><body><h1>Authentication failed.</h1>"
+                    b"<p>Error exchanging code for session.</p></body></html>"
+                )
+
+            # Shutdown server after handling the request
+            threading.Thread(target=self.server.shutdown).start()
+        else:
+            self.wfile.write(
+                b"<html><body><h1>Authentication failed.</h1>"
+                b"<p>No authorization code found.</p></body></html>"
+            )
+
+
+def handle_login_flow() -> None:
+    console.print(
+        render_status_panel(
+            ["[bold]Logging in with github...[/bold]"],
+            ["This will open a browser window for authentication..."],
+        )
+    )
+    console.print()
+
+    response = supabase.auth.sign_in_with_oauth(
+        {"provider": "github", "options": {"redirect_to": "http://localhost:3000"}}
+    )
+
+    console.print(
+        f"If your browser has not opened this automatically, follow this link: [link={response.url}]{response.url}[/link]"
+    )
+    webbrowser.open(response.url)
+
+    with console.status(
+        "[bold green]Waiting for authentication...", spinner="dots"
+    ) as status:
+        with HTTPServer(("localhost", 3000), OAuthCallbackHandler) as httpd:
+            status.update("Starting local server to capture authentication code.")
+            httpd.serve_forever()

--- a/cli_unites/core/config.py
+++ b/cli_unites/core/config.py
@@ -5,6 +5,7 @@ single JSON document stored under the user's home directory. The location can be
 overridden via the `CLI_UNITES_CONFIG_DIR` environment variable which makes it
 straightforward to isolate state during tests.
 """
+
 from __future__ import annotations
 
 import json
@@ -16,6 +17,7 @@ CONFIG_DIR_ENV = "CLI_UNITES_CONFIG_DIR"
 CONFIG_FILENAME = "config.json"
 DEFAULT_CONFIG: Dict[str, Any] = {
     "auth_token": None,
+    "refresh_token": None,
     "team_id": None,
     "supabase_url": None,
     "supabase_key": None,
@@ -90,7 +92,9 @@ def save_config(config: Dict[str, Any], config_dir: Optional[Path] = None) -> No
     manager.save()
 
 
-def update_config(updates: Dict[str, Any], config_dir: Optional[Path] = None) -> Dict[str, Any]:
+def update_config(
+    updates: Dict[str, Any], config_dir: Optional[Path] = None
+) -> Dict[str, Any]:
     manager = ConfigManager(config_dir=config_dir)
     manager.update(updates)
     return manager.as_dict()

--- a/cli_unites/templates/error.html
+++ b/cli_unites/templates/error.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Authentication Failed</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: #f0f2f5;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            text-align: center;
+            background-color: #fff;
+            padding: 40px;
+            border-radius: 10px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #dc3545;
+            font-size: 24px;
+            margin-bottom: 20px;
+        }
+        p {
+            color: #333;
+            font-size: 16px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Authentication Failed</h1>
+        <p>Something went wrong. Please try again.</p>
+    </div>
+</body>
+</html>

--- a/cli_unites/templates/success.html
+++ b/cli_unites/templates/success.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Authentication Successful</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: #f0f2f5;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            text-align: center;
+            background-color: #fff;
+            padding: 40px;
+            border-radius: 10px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #28a745;
+            font-size: 24px;
+            margin-bottom: 20px;
+        }
+        p {
+            color: #333;
+            font-size: 16px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Authentication Successful!</h1>
+        <p>You can now close this window and return to the CLI.</p>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
+    <script>
+        // Trigger confetti on page load
+        confetti({
+            particleCount: 100,
+            spread: 70,
+            origin: { y: 0.6 }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR introduces authentication commands for the CLI, allowing users to log in and out via GitHub OAuth.

## Changes include
`notes login`  
  - Initiates GitHub OAuth flow.  
  - Opens a browser for user authentication.  
  - Captures the authorization code via a local HTTP server (`OAuthCallbackHandler`).  
  - Exchanges the code for a session and stores the access and refresh tokens in the configuration.

`notes logout`  
  - Clears stored authentication tokens from the configuration.

## To test
1. Try logging in via `notes login`
2. Check your status via `notes auth`
3. Try logging out via `notes logout`
4. Check your status again. 

## Next steps / future improvements
- Improve token refresh handling.
- Intergrate it with supabase RLS. 
---
- solves #1 
