### PR TITLE
Auth token from login attatched to client

### DIFF
--- a/cli_unites/database/create_client.py
+++ b/cli_unites/database/create_client.py
@@ -1,14 +1,44 @@
-from dotenv import load_dotenv
-from supabase import create_client, Client
-from supabase.client import ClientOptions
-import psycopg2
+from supabase import create_client
+from ..core.config import ConfigManager
 import os
 
-load_dotenv()
+config = ConfigManager()
+auth_token = config.get("auth_token")
+refresh_token = config.get("refresh_token")
 
-# supabase connection variables
-url: str = os.getenv("SUPABASE_URL")
-key: str = os.getenv("SUPABASE_KEY")
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 
-# creating supabase client
-supabase: Client = create_client(url, key)
+supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+if auth_token:
+    if refresh_token:
+        try:
+            supabase.auth.set_session(auth_token, refresh_token)
+        except Exception as e:
+            print(f"Warning: supabase.auth.set_session failed: {e}")
+            supabase.auth.session = {
+                "access_token": auth_token,
+                "refresh_token": None,
+            }
+    else:
+        # No refresh token, just set access token manually
+        supabase.auth.session = {
+            "access_token": auth_token,
+            "refresh_token": None,
+        }
+
+user_resp = supabase.auth.get_user()
+
+user = None
+if user_resp:
+    if hasattr(user_resp, "user"):
+        user = user_resp.user
+    elif getattr(user_resp, "data", None) and hasattr(user_resp.data, "user"):
+        user = user_resp.data.user
+
+# Debugging: 
+# if user:
+#     print(f"Logged in as: {user.id} ({user.email})")
+# else:
+#     print("No valid user session found")


### PR DESCRIPTION
### Attach Supabase Auth Session to Client

This PR enables automatic authentication by attaching stored Supabase tokens to the client during initialization.

#### ✅ What’s Included
- Load `auth_token` and `refresh_token` using `ConfigManager`
- Attempt `supabase.auth.set_session`, with manual fallback if needed
- Retrieve active user via `supabase.auth.get_user()`
- Display authenticated user for confirmation

#### 🛠 Example Output
Logged in as: 023f563b-6305-4b64-bbc6-32c3d2d74d70 (richardcouzens96@gmail.com)

#### 🔒 Benefit
Allows CLI to use existing sessions and so RLS

