### PR TITLE
chore: added missing command comments and reworked help command

### DIFF
--- a/cli_unites/commands/help.py
+++ b/cli_unites/commands/help.py
@@ -7,20 +7,10 @@ from ..core import console
 
 HELP_CONTENT = """[bold]cli-unites quick start[/bold]
 
-• [bold]Authentication[/bold]: `notes auth --token TOKEN --team-id TEAM`
-• [bold]Login[/bold]: `notes login`
-• [bold]Logout[/bold]: `notes logout`
-• [bold]Add Note[/bold]: `notes add "Title" --body "Details"`
-• [bold]List Notes[/bold]: `notes list --tag release`
-• [bold]Search Notes[/bold]: `notes search "keyword"`
-• [bold]Switch Team[/bold]: `notes team --set my-team`
-• [bold]Team Activity[/bold]: `notes activity --limit 5`
+Run `notes --help` to see all available commands.
 
+For first-time setup and onboarding, please refer to the onboarding guide.
 
-Tips:
-- Omit `--body` to open an editor or pipe text from another command.
-- Use `--allow-empty` when logging quick todo stubs.
-- Run with `--debug` for verbose trace output when something breaks.
 """
 
 
@@ -29,10 +19,3 @@ Tips:
 def help_command(topic: str | None) -> None:
     """Show usage tips and quick links."""
     console.print(Panel.fit(HELP_CONTENT, border_style="cyan"))
-    if topic:
-        console.print(
-            (
-                f"[dim]No detailed walkthrough for [bold]{topic}[/bold] yet. "
-                "Try the README or `notes help` without a topic.[/dim]"
-            )
-        )

--- a/cli_unites/commands/login.py
+++ b/cli_unites/commands/login.py
@@ -5,4 +5,5 @@ from ..core.auth import handle_login_flow
 
 @click.command(name="login")
 def login() -> None:
+    """Login with your github account."""
     handle_login_flow()

--- a/cli_unites/commands/logout.py
+++ b/cli_unites/commands/logout.py
@@ -4,8 +4,10 @@ from ..core.output import print_success
 from ..core.config import ConfigManager
 
 
+# This doesn't actually log you out yet.
 @click.command(name="logout")
 def logout() -> None:
+    """Log out of your github account."""
     config = ConfigManager()
     config.update({"auth_token": None, "refresh_token": None})
     print_success("Successfully logged out and cleared authentication tokens.")


### PR DESCRIPTION
Added comments to the log out and log in command so they are displayed here: 

╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
│ activity                Show recent notes for the current or selected team.                      
│ add                     Add a note to your team's knowledge base.                                
│ auth                    Manage authentication details.                                           
│ help                    Show usage tips and quick links.                                         
│ list                    List stored notes.                                                       
│ login                   Login with your github account.                                          
│ logout                  Log out of your github account.                                          
│ onboarding              Launch the interactive onboarding tour.                                  
│ realtime                Work with Supabase Realtime events.                                      
│ search                  Search notes by keyword.                                                 
│ semantic-search         Search notes using semantic similarity (AI-powered).          
│ team                    Display or update the default team id.  


Made it so help command just points to 'notes -h' which is auto generated so won't need updating. 